### PR TITLE
Adding fix to Sonoff DUAL power status

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,11 @@ function MqttSwitchTasmotaAccessory(log, config) {
 }
 
 MqttSwitchTasmotaAccessory.prototype.getStatus = function(callback) {
-	callback(null, this.switchStatus);
+	if (this.activeStat) {
+		callback(null, this.switchStatus);
+	} else {
+		callback(no_response);		
+	}
 }
 
 MqttSwitchTasmotaAccessory.prototype.setStatus = function(status, callback, context) {

--- a/index.js
+++ b/index.js
@@ -106,11 +106,20 @@ function MqttSwitchTasmotaAccessory(log, config) {
 	this.client.on('message', function(topic, message) {
 		if (topic == that.topicStatusGet) {
 			try {
+				// In the event that the user has a DUAL the topicStatusGet will return for POWER1 or POWER2 in the JSON.  
+				// We need to coordinate which accessory is actually being reported and only take that POWER data.  
+				// This assumes that the Sonoff single will return the value { "POWER" : "ON" }
 				var data = JSON.parse(message);
 				var status = data.POWER;
-				that.switchStatus = (status == that.onValue);
+				if(data.hasOwnProperty(that.powerValue)){
+				  var status = data[that.powerValue];
+				  that.switchStatus = (status == that.onValue);
+				  that.log(that.name, "(",that.powerValue,") - Power from Status", status); //TEST ONLY
+				}
+				
 			} catch (e) {
 				var status = message.toString();
+
 				that.switchStatus = (status == that.onValue);
 			}
 			that.service.getCharacteristic(Characteristic.On).setValue(that.switchStatus, undefined, 'fromSetValue');
@@ -121,7 +130,7 @@ function MqttSwitchTasmotaAccessory(log, config) {
 				var data = JSON.parse(message);
 				if (data.hasOwnProperty(that.powerValue)) {
 					var status = data[that.powerValue];
-					that.log(that.name, " - Power from State", status); //TEST ONLY
+					that.log(that.name, "(",that.powerValue,") - Power from State", status); //TEST ONLY
 					that.switchStatus = (status == that.onValue);
 					that.service.getCharacteristic(Characteristic.On).setValue(that.switchStatus, undefined, '');
 				}
@@ -145,7 +154,7 @@ MqttSwitchTasmotaAccessory.prototype.getStatus = function(callback) {
 	if (this.activeStat) {
 		callback(null, this.switchStatus);
 	} else {
-		callback(no_response);		
+		callback(null);		
 	}
 }
 


### PR DESCRIPTION
The Dual returns the message { POWER1 : ON } or { POWER2 : ON } whereas the regular Sonoff switch is { POWER : ON } This patch makes it look at the correct Power only.

Also, @Arduingo your fix was throwing an error, where the no_callback was not defined.  I set that to null.